### PR TITLE
[WORKFLOWS-468] Disable caching on `get_user_id` process

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -53,6 +53,8 @@ process get_user_id {
   
   label 'synapse'
 
+  cache false
+
   secret 'SYNAPSE_AUTH_TOKEN'
 
   afterScript "rm -f ${syn_config}"


### PR DESCRIPTION
Unfortunately, a changed value in a Nextflow secret doesn't invalidate cached jobs, so I need to manually disable any caching on the `get_user_id` process. Otherwise, you might end up in a situation where a job was cached with a different user, thereby causing issue during Synapse indexing if the current user isn't listed in the `owner.txt` file. 