### PR TITLE
[WORKFLOWS-478] Document ability to index any S3 bucket along with caveat regarding MD5 checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you require high-fidelity MD5 checksums, make a feature request. This could b
 
 ### Indexing non-Tower buckets
 
-While this workflow was originally created to enable Synapse indexing in Nextflow Tower, it is generic enough to support all S3 buckets as long as the workflow has permissions to the bucket in question. If you plan on running this workflow in Tower, open a ticket to request for the IAM role ARNs that must be granted access to the target bucket (_e.g._ on the bucket policy).
+While this workflow was originally created to enable Synapse indexing in Nextflow Tower, it is generic enough to support all S3 buckets as long as the workflow has permissions to the bucket in question. If you plan on running this workflow in Tower, open a ticket to request the IAM role ARNs that must be granted access to the target bucket (_e.g._ on the bucket policy).
 
 If you have access to MD5 checksums, you should use those instead of the ones computed by this workflow (for the reason explained in the above caveat). Currently, this workflow doesn't support providing pre-computed MD5 checkums. Feel free to open a feature request if this use case becomes relevant to you.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The benefits of using this workflows include:
 
 Nextflow does not compute MD5 checksums for published files. Hence, this workflow must compute these checksums post hoc. Unfortunately, there is no guarantee on the integrity of the file transfer from S3 to the EC2 instances that will compute the checksums. While the risk is minimized by remaining within the AWS network, it remains non-zero. 
 
-If you require high-fidelity MD5 checksums, make a feature request. This could be achieved by downloading each file more than once and ensuring consistency in the computed checksums.
+If you require high-fidelity MD5 checksums, make a feature request. For example, the workflow could download each file more than once and ensure consistency in the computed checksums. This isn't implemented yet.
 
 ### Indexing non-Tower buckets
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The benefits of using this workflows include:
 
 ### Caveat with computing MD5 checksums for Nextflow output files
 
-Nextflow does not compute MD5 checksums for published files. Hence, this workflow must compute these checksums post hoc. Unfortunately, there is on guarantee on the integrity of the file transfer from S3 to the EC2 instances that will compute the checksums. While the risk is minimized by remaining within the AWS network, it remains non-zero. 
+Nextflow does not compute MD5 checksums for published files. Hence, this workflow must compute these checksums post hoc. Unfortunately, there is no guarantee on the integrity of the file transfer from S3 to the EC2 instances that will compute the checksums. While the risk is minimized by remaining within the AWS network, it remains non-zero. 
 
 If you require high-fidelity MD5 checksums, make a feature request. This could be achieved by downloading each file more than once and ensuring consistency in the computed checksums.
 


### PR DESCRIPTION
This PR is purely a documentation update. The diffs should be self-explanatory. 