### PR TITLE
[IBCSPRT-166] increase memory usage for synapse_index step

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,10 @@ process {
 		container = 'quay.io/brunograndephd/aws-cli:latest'
 	}
 
+	withName: synapse_index {
+		memory = 16.GB
+		cpus = 4
+	}
 }
 
 manifest {


### PR DESCRIPTION
Increase the memory usage for the synapse index step, since we seem to be running into a "Cannot Allocate Memory" error during the step on a cram file that is ~6GB.

This is a bit strange for me, because I feel like we've probably run this workflow on larger files...