### PR TITLE
Update to DSL2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM ubuntu:22.04
 
 WORKDIR /root
 
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
 	curl \
-	unzip
+	unzip \
+	jq
+
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /root
 
 RUN apt-get update && apt-get install -y \
 	curl \
-	unzip \
-	jq
+	unzip
+	# jq
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
+
+COPY synapse_creds.sh synapse_creds.sh

--- a/main.nf
+++ b/main.nf
@@ -13,7 +13,6 @@ nextflow.enable.dsl = 2
 // Default values
 params.s3_prefix = false
 params.parent_id = false
-params.synapse_config = false
 
 if ( !params.s3_prefix ) {
   exit 1, "Parameter 'params.s3_prefix' is required!\n"
@@ -41,8 +40,6 @@ if ( matches.size() == 0 ) {
 if ( !params.parent_id ==~ 'syn[0-9]+' ) {
   exit 1, "Parameter 'params.parent_id' must be the Synapse ID of a folder (e.g., 'syn98765432')!\n"
 }
-
-ch_synapse_config = params.synapse_config ? Channel.value( file(params.synapse_config) ) : "null"
 
 publish_dir = "${s3_prefix}/synindex/under-${params.parent_id}/"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,7 +10,8 @@ process {
 	}
 
 	withLabel: aws {
-		container = 'quay.io/brunograndephd/aws-cli:latest'
+		container = 'test'
+		// container = 'quay.io/brunograndephd/aws-cli:latest'
 	}
 
 	withName: synapse_index {


### PR DESCRIPTION
When updating this to DSL2/general exploration to make this work locally on any synapse linked S3 bucket, here are some issues I ran into:

1. The original use case of this workflow was not meant to be run locally, but there is interest in being able to execute this on an ec2 or locally on any s3 bucket linked to Synapse.
2. If we were to make this work with a service catalog created s3 bucket, AWS credentials need to be provided to many of the processes.
3. path: null is an issue for the synapse config.
4. synapse_index runs into permission issues (from not having access to the s3 objects). This becomes a lot more complicated for service catalog linked s3 buckets.

Through this, here are the steps to enabling DSL2
1. deprecate synapse config
2. update to DSL2

Then we can determine how best to potentially support a use case for running this tool locally.  Leaving this as draft for reference.

