### PR TITLE
Add input parameter to allow file filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ If you have access to MD5 checksums, you should use those instead of the ones co
 ### Additional Limitations
 
 - The workflow doesn't annotate the Synapse files it creates with any metadata or provenance.
-- The workflow will index all of the objects under the given S3 prefix. There is no way to filter or skip the indexing of certain objects.
 
 ## Summary
 
@@ -137,3 +136,5 @@ Check out the [Quickstart](#quickstart) section for example parameter values.
 - **`parent_id`**: (Required) The Synapse ID of a Synapse folder that will contain the indexed files and the associated folder structure.
 
 - **`synapse_config`**: (Optional) A [Synapse configuration file](https://python-docs.synapse.org/build/html/Credentials.html#use-synapseconfig) containing authentication credentials. 
+
+- **`filename_string`**: (Optional) A string that allows you to filter files that are contained in your S3 prefix. When provided, only files that contain the filename_string in the filename will be indexed on Synapse. 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The examples below demonstrate how you would index objects under an S3 prefix in
     ```yaml
     s3_prefix: "s3://example-bucket/outputs/"
     parent_id: "syn26601236"
+    filename_string: "g.vcf"
     ```
 
 5. Launch workflow using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run), the [Tower CLI](https://help.tower.nf/latest/cli/), or the [Tower web UI](https://help.tower.nf/latest/launch/launchpad/).

--- a/main.nf
+++ b/main.nf
@@ -146,6 +146,7 @@ process list_objects {
     -e 'synapseConfig' -e 'synapse_config' \
   | awk '{\$1=\$2=\$3=""; print \$0}' \
   | sed 's|^   |s3://${bucket}/|' \
+  ${filename_string ? "| grep '${filename_string}'" : ""} \  // Filter files based on string in filename (optional)
   > objects.txt
   """
   

--- a/main.nf
+++ b/main.nf
@@ -14,6 +14,7 @@ nextflow.enable.dsl = 1
 params.s3_prefix = false
 params.parent_id = false
 params.synapse_config = false
+params.filename_string = false
 
 if ( !params.s3_prefix ) {
   exit 1, "Parameter 'params.s3_prefix' is required!\n"
@@ -135,6 +136,7 @@ process list_objects {
   input:
   val s3_prefix from s3_prefix
   val bucket    from bucket_name
+  val filename_string from params.filename_string
 
   output:
   path 'objects.txt'    into ch_objects

--- a/main.nf
+++ b/main.nf
@@ -148,7 +148,7 @@ process list_objects {
     -e 'synapseConfig' -e 'synapse_config' \
   | awk '{\$1=\$2=\$3=""; print \$0}' \
   | sed 's|^   |s3://${bucket}/|' \
-  ${filename_string ? "| grep '${filename_string}'" : ""} \  // Filter files based on string in filename (optional)
+  ${filename_string ? "| grep '${filename_string}'" : ""} \
   > objects.txt
   """
   


### PR DESCRIPTION
This PR alleviates a major restriction in the synindex pipeline by allowing the filtering of objects contained in the specified S3 prefix. By adding an optional filename_string input parameter when running the pipeline, the user can now specify a specific type of file that they want to index, while ignoring other files that are present within the S3 path. 